### PR TITLE
Fix uses of `==` to compare Strings in Java

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,21 +13,22 @@ crossPaths := false
 
 autoScalaLibrary := false
 
-resolvers ++= Seq("releases" at "http://oss.sonatype.org/content/repositories/releases",
-                  "snapshots" at "http://oss.sonatype.org/content/repositories/snapshots",
-                  "localmaven" at "file://"+Path.userHome+"/.m2/repository")
-
-publishTo <<= version { v: String =>
+publishTo := {
+  val v = version.value
   val nexus = "https://oss.sonatype.org/"
   if (v.trim.endsWith("SNAPSHOT")) Some("publish-snapshots" at nexus + "content/repositories/snapshots")
   else                             Some("publish-releases" at nexus + "service/local/staging/deploy/maven2")
 }
 
-libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.0.M6-SNAP24" % "test"
+libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.0" % Test
 
 publishMavenStyle := true
 
-publishArtifact in Test := false
+// Tests must be forked in this repo; otherwise the tests will use the classes from sbt.testing._
+// provided by sbt rather than the ones compiled from these sources.
+Test / fork := true
+
+Test / publishArtifact := false
 
 pomIncludeRepository := { _ => false }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.4
+sbt.version=1.9.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")

--- a/src/main/java/sbt/testing/NestedSuiteSelector.java
+++ b/src/main/java/sbt/testing/NestedSuiteSelector.java
@@ -36,7 +36,7 @@ public final class NestedSuiteSelector extends Selector implements Serializable 
     boolean retVal = false;
     if (o instanceof NestedSuiteSelector) {
       NestedSuiteSelector nss = (NestedSuiteSelector) o;
-      retVal = nss._suiteId == _suiteId;
+      retVal = nss._suiteId.equals(_suiteId);
     }
     return retVal;
   }

--- a/src/main/java/sbt/testing/TestSelector.java
+++ b/src/main/java/sbt/testing/TestSelector.java
@@ -36,7 +36,7 @@ public final class TestSelector extends Selector implements Serializable {
     boolean retVal = false;
     if (o instanceof TestSelector) {
       TestSelector ts = (TestSelector) o;
-      retVal = ts._testName == _testName;
+      retVal = ts._testName.equals(_testName);
     }
     return retVal;
   }

--- a/src/main/java/sbt/testing/TestWildcardSelector.java
+++ b/src/main/java/sbt/testing/TestWildcardSelector.java
@@ -49,7 +49,7 @@ public final class TestWildcardSelector extends Selector implements Serializable
     boolean retVal = false;
     if (o instanceof TestWildcardSelector) {
       TestWildcardSelector tws = (TestWildcardSelector) o;
-      retVal = tws._testWildcard == _testWildcard;
+      retVal = tws._testWildcard.equals(_testWildcard);
     }
     return retVal;
   }

--- a/src/test/scala/sbt/testing/NestedSuiteSelectorSpec.scala
+++ b/src/test/scala/sbt/testing/NestedSuiteSelectorSpec.scala
@@ -14,6 +14,7 @@ class NestedSuiteSelectorSpec extends UnitSpec {
     def `should have a properly behaving equals method` {
       redNestedSuiteSelector shouldEqual redNestedSuiteSelector
       redNestedSuiteSelector shouldEqual new NestedSuiteSelector("red")
+      redNestedSuiteSelector shouldEqual new NestedSuiteSelector(red())
       redNestedSuiteSelector should not equal new NestedSuiteSelector("blue")
       redNestedSuiteSelector should not equal null
       redNestedSuiteSelector should not equal "howdy"

--- a/src/test/scala/sbt/testing/NestedTestSelectorSpec.scala
+++ b/src/test/scala/sbt/testing/NestedTestSelectorSpec.scala
@@ -22,6 +22,7 @@ class NestedTestSelectorSpec extends UnitSpec {
     def `should have a properly behaving equals method` {
       redBirdNestedTestSelector shouldEqual redBirdNestedTestSelector
       redBirdNestedTestSelector shouldEqual new NestedTestSelector("red", "bird")
+      redBirdNestedTestSelector shouldEqual new NestedTestSelector(red(), "bird")
       redBirdNestedTestSelector should not equal blueBirdNestedTestSelector
       redBirdNestedTestSelector should not equal redFishNestedTestSelector
       redBirdNestedTestSelector should not equal blueFishNestedTestSelector

--- a/src/test/scala/sbt/testing/TestSelectorSpec.scala
+++ b/src/test/scala/sbt/testing/TestSelectorSpec.scala
@@ -14,6 +14,7 @@ class TestSelectorSpec extends UnitSpec {
     def `should have a properly behaving equals method` {
       redTestSelector shouldEqual redTestSelector
       redTestSelector shouldEqual new TestSelector("red")
+      redTestSelector shouldEqual new TestSelector(red())
       redTestSelector should not equal new TestSelector("blue")
       redTestSelector should not equal null
       redTestSelector should not equal "howdy"

--- a/src/test/scala/sbt/testing/TestWildcardSelectorSpec.scala
+++ b/src/test/scala/sbt/testing/TestWildcardSelectorSpec.scala
@@ -14,6 +14,7 @@ class TestWildcardSelectorSpec extends UnitSpec {
     def `should have a properly behaving equals method` {
       redTestWildcardSelector shouldEqual redTestWildcardSelector
       redTestWildcardSelector shouldEqual new TestWildcardSelector("red")
+      redTestWildcardSelector shouldEqual new TestWildcardSelector(red())
       redTestWildcardSelector should not equal new TestWildcardSelector("blue")
       redTestWildcardSelector should not equal null
       redTestWildcardSelector should not equal "howdy"

--- a/src/test/scala/sbt/testing/UnitSpec.scala
+++ b/src/test/scala/sbt/testing/UnitSpec.scala
@@ -2,4 +2,6 @@ package sbt.testing
 
 import org.scalatest._
 
-class UnitSpec extends Spec with Matchers with prop.TableDrivenPropertyChecks
+class UnitSpec extends Spec with Matchers with prop.TableDrivenPropertyChecks {
+  def red(): String = "der".reverse
+}


### PR DESCRIPTION
Previously, several subclasses of `Selector` were using `==` to compare Strings in Java. `equals` must be used to compare Strings in Java. This lead to some selectors being wrongly considered different.

Now, all Strings are compared with `equals`, which yields the expected result.